### PR TITLE
Show parent directory for all index.* files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is not good! All the filenames are the same. Atom tries to be helpful by sh
 
 ### There must be a better way...
 
-What if, specifically for `index.js` and `index.jsx` files, we always just showed the parent directory? Something like:
+What if for all `index.*` files, we always just showed the parent directory? Something like:
 
 ![Better pane files](http://i.imgur.com/gM88FOR.png)
 

--- a/lib/nice-index.coffee
+++ b/lib/nice-index.coffee
@@ -34,8 +34,8 @@ module.exports = NiceIndex =
     elements = @getElementsArray 'li.tab .title'
 
     elements.forEach (el) =>
-      # Match `index.js` and `index.jsx`
-      if el.getAttribute('data-name')?.match(/^index.js/)
+      # Match any `index.` file
+      if el.getAttribute('data-name')?.match(/^index.*/)
         el.innerText = '/' + @getDirectoryName(el)
       else
         el.innerText = el.getAttribute('data-name')


### PR DESCRIPTION
Don't just limit the package to `index.js` and `index.jsx` files, but for all `index.*` files.
For example, `index.css` will also show the parent folder name.
