### PR TITLE
Add config menu for adding file matchers

### DIFF
--- a/lib/nice-index.coffee
+++ b/lib/nice-index.coffee
@@ -5,6 +5,15 @@ path = require('path')
 module.exports = NiceIndex =
   subscriptions: null
 
+  config:
+    fileNames:
+      type: 'array'
+      default: [
+        'index.*'
+      ]
+      description: "Regex patterns of file names to match"
+      items:
+        type: 'string'
 
   activate: (state) ->
     @subscriptions = new CompositeDisposable
@@ -33,9 +42,12 @@ module.exports = NiceIndex =
   renameTabs: ->
     elements = @getElementsArray 'li.tab .title'
 
+    fileNames = atom.config.get('nice-index.fileNames')
+    regex = new RegExp('^' + fileNames.join('|'))
+
     elements.forEach (el) =>
       # Match any `index.` file
-      if el.getAttribute('data-name')?.match(/^index.*/)
+      if el.getAttribute('data-name')?.match(regex)
         el.innerText = '/' + @getDirectoryName(el)
 
   getDirectoryName: (el) ->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nice-index",
   "main": "./lib/nice-index",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Show directory names instead of `index.js`.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I wanted to customize the behavior of this awesome plugin to match an additional range of file types (`styles.less`, `__init__.py`, etc.). This PR adds a config menu option for adding additional file matching regex pieces.

The only caveat right now is that any changes in the config menu are not immediately reflected in the tabs - you have to either open a new tab or close an open tab for the changes to be displayed